### PR TITLE
Feat: 서브 모듈, UI 컴포넌트 및 스토리북 생성 기능 추가

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change Log
 
+## [0.3.1] - 2022-08-11
+### Fixed
+
+- common 과 shared 모듈에서 UI 컴포넌트 생성 컨텍스트 메뉴가 뜨지 않던 부분을 수정합니다.
+
+## [0.3.0] - 2022-08-10
+### Changed
+
+- `Add Sub Module` 기능이 추가되었습니다.
+- `Add UI Component with Storybook` 기능이 추가되었습니다.
+- `Add Storybook for This Component` 기능이 추가되었습니다.
+- 좌측 탐색기 내 우클릭된 파일과 폴더별로 다른 컨텍스트 메뉴가 나오도록 표현 조건을 보완하였습니다.
+
 ## [0.2.4] - 2022-08-03
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,19 @@
 # Change Log
 
-All notable changes to the "test-extension" extension will be documented in this file.
+## [0.2.4] - 2022-08-03
+### Changed
 
-Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
+- 기존 `npx` 가 아닌 각 프로젝트에 설치된 `ts-fe-cli` 를 직접 수행하도록 변경하였습니다.
+- vscode 1.60.0 이상에서 수행할 수 있도록 최소 수행 버전 기준이 완화되었습니다.
 
-## [Unreleased]
+## [0.2.0] - 2022-08-02
+### Added
 
-- Initial release
+- `Add Feature Module` 기능이 추가되었습니다.
+- 좌측 탐색기(explorer) 에서 typescript 나 폴더 계통에서 우클릭 하면 나타납니다.
+
+## [References]
+
+본 파일은 아래 내용을 바탕으로 포멧을 맞추고 있습니다.
+
+- [Keep a Changelog](http://keepachangelog.com/)

--- a/README.md
+++ b/README.md
@@ -2,4 +2,23 @@
 
 업무용으로 ts-fe-cli 와 함께 사용하기 위한 vscode 확장 프로그램 입니다.
 
-개발 중입니다. 😅
+현재 개발 중입니다. 😅
+
+## Pre Dependency
+
+본 확장 프로그램 사용 전, 반드시 아래와 같이 [ts-fe-cli](https://github.com/thesoncriel/ts-fe-cli)를 먼저 설치하시기 바랍니다~ 🙌
+
+```sh
+$ npm i -D ts-fe-cli@latest
+```
+
+그리고 프로젝트 내 `package.json` 에 아래와 같이 script 를 추가 해주세요~!
+```json
+{
+  "scripts": {
+    "cli": "ts-fe-cli"
+  },
+}
+```
+
+그럼 즐코하세요~ 👍

--- a/README.md
+++ b/README.md
@@ -22,3 +22,15 @@ $ npm i -D ts-fe-cli@latest
 ```
 
 그럼 즐코하세요~ 👍
+
+## How To Test
+
+먼저 watch 모드를 수행하여 파일 변경 시 자동으로 빌드 되도록 합니다.
+
+```sh
+$ npm run watch
+```
+
+그리고 `src/extension.ts` 파일을 열고 `cmd + shift + d` 를 누른 뒤 좌측 상단 `Run and Debug` 를 눌러줍니다.
+
+테스트용 vscode 새창이 열리면, 적절한 프로젝트를 불러와서 테스트를 합니다~!

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ts-fe-vscode-extension",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ts-fe-vscode-extension",
-      "version": "0.2.1",
+      "version": "0.2.3",
       "devDependencies": {
         "@types/glob": "^7.2.0",
         "@types/mocha": "^9.1.1",
@@ -25,7 +25,7 @@
         "webpack-cli": "^4.10.0"
       },
       "engines": {
-        "vscode": "^1.60.0"
+        "vscode": "^1.60.x"
       }
     },
     "node_modules/@discoveryjs/json-ext": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ts-fe-vscode-extension",
   "displayName": "ts-fe-vscode-extension",
   "description": "vscode extension for ts-fe-cli",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "publisher": "theson",
   "engines": {
     "vscode": "^1.60.x"
@@ -31,12 +31,12 @@
           "command": "ts-fe-vscode-extension.sub-add"
         },
         {
-          "when": "explorerResourceIsFolder && resourcePath =~ /(features|shared|common)\/\\w+\/components/\\w+/",
+          "when": "explorerResourceIsFolder && resourcePath =~ /(features\/\\w+|shared|common)\/components/\\w+/",
           "group": "z_commands",
           "command": "ts-fe-vscode-extension.ui-add"
         },
         {
-          "when": "resourceExtname == .tsx && resourcePath =~ /(features|shared|common)\/\\w+\/components/",
+          "when": "resourceExtname == .tsx && resourcePath =~ /(features\/\\w+|shared|common)\/components/",
           "group": "z_commands",
           "command": "ts-fe-vscode-extension.sb-add"
         }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ts-fe-vscode-extension",
   "displayName": "ts-fe-vscode-extension",
   "description": "vscode extension for ts-fe-cli",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "publisher": "theson",
   "engines": {
     "vscode": "^1.60.x"
@@ -11,16 +11,34 @@
     "Other"
   ],
   "activationEvents": [
-    "onCommand:ts-fe-vscode-extension.feat-add"
+    "onCommand:ts-fe-vscode-extension.feat-add",
+    "onCommand:ts-fe-vscode-extension.sub-add",
+    "onCommand:ts-fe-vscode-extension.ui-add",
+    "onCommand:ts-fe-vscode-extension.sb-add"
   ],
   "main": "./dist/extension.js",
   "contributes": {
     "menus": {
       "explorer/context": [
         {
-          "when": "explorerResourceIsFolder || resourceLangId == typescript || resourceLangId == typescriptreact",
+          "when": "explorerResourceIsFolder && resourcePath =~ /features/",
           "group": "z_commands",
           "command": "ts-fe-vscode-extension.feat-add"
+        },
+        {
+          "when": "explorerResourceIsFolder && resourcePath =~ /features\/\\w+|shared/",
+          "group": "z_commands",
+          "command": "ts-fe-vscode-extension.sub-add"
+        },
+        {
+          "when": "explorerResourceIsFolder && resourcePath =~ /(features|shared|common)\/\\w+\/components/\\w+/",
+          "group": "z_commands",
+          "command": "ts-fe-vscode-extension.ui-add"
+        },
+        {
+          "when": "resourceExtname == .tsx && resourcePath =~ /(features|shared|common)\/\\w+\/components/",
+          "group": "z_commands",
+          "command": "ts-fe-vscode-extension.sb-add"
         }
       ]
     },
@@ -28,6 +46,18 @@
       {
         "command": "ts-fe-vscode-extension.feat-add",
         "title": "Add Feature Module"
+      },
+      {
+        "command": "ts-fe-vscode-extension.sub-add",
+        "title": "Add Sub Module"
+      },
+      {
+        "command": "ts-fe-vscode-extension.ui-add",
+        "title": "Add UI Component with Storybook"
+      },
+      {
+        "command": "ts-fe-vscode-extension.sb-add",
+        "title": "Add Storybook for This Component"
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ts-fe-vscode-extension",
   "displayName": "ts-fe-vscode-extension",
   "description": "vscode extension for ts-fe-cli",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "publisher": "theson",
   "engines": {
     "vscode": "^1.60.x"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,8 +13,7 @@ interface VscodeExplorerContextDto {
 function executeFeatureModule(feature: string, sub: string) {
 	const terminal = vscode.window.createTerminal(`ts-fe-cli-temp-${Date.now()}`);
 
-	// terminal.show();
-	terminal.sendText(`npx ts-fe-cli feat add ${feature}/${sub}`);
+	terminal.sendText(`npm run cli feat add ${feature}/${sub}`);
 	terminal.sendText('y');
 
 	setTimeout(() => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,13 +13,46 @@ interface VscodeExplorerContextDto {
 function executeFeatureModule(feature: string, sub: string) {
 	const terminal = vscode.window.createTerminal(`ts-fe-cli-temp-${Date.now()}`);
 
-	terminal.sendText(`npm run cli feat add ${feature}/${sub}`);
+	terminal.sendText(`npm run cli feat ${feature} ${sub}`);
 	terminal.sendText('y');
 
 	setTimeout(() => {
 		terminal.dispose();
 	}, 5000);
-};
+}
+
+function executeSubModule(path: string, sub: string) {
+	const terminal = vscode.window.createTerminal(`ts-fe-cli-temp-${Date.now()}`);
+
+	terminal.sendText(`npm run cli sub ${path} ${sub}`);
+	terminal.sendText('y');
+
+	setTimeout(() => {
+		terminal.dispose();
+	}, 5000);
+}
+
+function executeUiComponent(path: string, componentName: string, type: string) {
+	const terminal = vscode.window.createTerminal(`ts-fe-cli-temp-${Date.now()}`);
+
+	terminal.sendText(`npm run cli ui ${path} ${componentName} ${type}`);
+	terminal.sendText('y');
+
+	setTimeout(() => {
+		terminal.dispose();
+	}, 5000);
+}
+
+function executeStorybook(path: string, type: string) {
+	const terminal = vscode.window.createTerminal(`ts-fe-cli-temp-${Date.now()}`);
+
+	terminal.sendText(`npm run cli sb ${path} ${type}`);
+	terminal.sendText('y');
+
+	setTimeout(() => {
+		terminal.dispose();
+	}, 5000);
+}
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
@@ -32,7 +65,7 @@ export function activate(context: vscode.ExtensionContext) {
 	// The command has been defined in the package.json file
 	// Now provide the implementation of the command with registerCommand
 	// The commandId parameter must match the command field in package.json
-	let disposable = vscode.commands.registerCommand('ts-fe-vscode-extension.feat-add', (arg0: VscodeExplorerContextDto, arg1: VscodeExplorerContextDto[]) => {
+	let disposableFeatAdd = vscode.commands.registerCommand('ts-fe-vscode-extension.feat-add', (arg0: VscodeExplorerContextDto, arg1: VscodeExplorerContextDto[]) => {
 		// The code you place here will be executed every time your command is executed
 		// Display a message box to the user
 		// vscode.window.showInformationMessage(JSON.stringify(arg0) + '\n------\n' + JSON.stringify(arg1));
@@ -69,7 +102,73 @@ export function activate(context: vscode.ExtensionContext) {
 		input1.show();
 	});
 
-	context.subscriptions.push(disposable);
+	let disposableSubAdd = vscode.commands.registerCommand('ts-fe-vscode-extension.sub-add', (arg0: VscodeExplorerContextDto, arg1: VscodeExplorerContextDto[]) => {
+		const input = vscode.window.createInputBox();
+
+		input.title = 'sub name ?';
+		input.ignoreFocusOut = true;
+
+		input.onDidAccept(() => {
+			if (!input.value.trim()) {
+				input.validationMessage = 'input please~';
+
+				return;
+			}
+			input.hide();	
+			executeSubModule(arg0.path, input.value.trim());
+		});
+
+		input.show();
+	});
+
+	let disposableUiAdd = vscode.commands.registerCommand('ts-fe-vscode-extension.ui-add', (arg0: VscodeExplorerContextDto, arg1: VscodeExplorerContextDto[]) => {
+
+		const input = vscode.window.createInputBox();
+
+		input.title = 'component name ?';
+		input.ignoreFocusOut = true;
+
+		const pick = vscode.window.createQuickPick();
+
+		pick.title = 'component type ?';
+		pick.canSelectMany = false;
+		
+		input.onDidAccept(() => {
+			if (!input.value.trim()) {
+				input.validationMessage = 'input please~';
+
+				return;
+			}
+			input.hide();	
+			pick.show();
+			vscode.window.showQuickPick([
+				'normal', 'memo', 'dialog', 'imperative'
+			])
+			.then(pickValue => {
+				pickValue && executeUiComponent(arg0.path, input.value.trim(), pickValue);
+			});
+		
+		});
+
+		input.show();
+	});
+
+	let disposableStorybookAdd = vscode.commands.registerCommand('ts-fe-vscode-extension.sb-add', (arg0: VscodeExplorerContextDto, arg1: VscodeExplorerContextDto[]) => {
+		const pick = vscode.window.createQuickPick();
+
+		pick.title = 'component type ?';
+		pick.canSelectMany = false;
+		
+		pick.show();
+			vscode.window.showQuickPick([
+				'normal', 'dialog', 'imperative'
+			])
+			.then(pickValue => {
+				pickValue && executeStorybook(arg0.path, pickValue);
+			});
+	});
+
+	context.subscriptions.push(disposableFeatAdd, disposableSubAdd, disposableUiAdd, disposableStorybookAdd);
 }
 
 // this method is called when your extension is deactivated


### PR DESCRIPTION
## Updates <!-- 추가 되거나 바뀐 내용 -->

- 서브 모듈과 React UI Component 및 Storybook 비주얼 테스트를 자동으로 만들어주는 기능을 추가합니다.
- 각 생성 명령을 수행하는 하위 메뉴들을 좌측 탐색기에서 선택된 파일 및 폴더 타입에 따라 다른 내용을 보여주도록 기능 개선하였습니다.
- 이전 버전에서 `npx` 로 수행하던 cli 를 각 프로젝트별로 설정된 cli 를 직접 수행하도록 변경하였습니다.

### Add Sub Module
- features 폴더 내 이미 만들어진 특정 feature module 폴더를 우클릭 하거나 shared 폴더를 우클릭 하면 나타납니다.
- 이미 만들어진 모듈 기준, redux store 를 자동으로 만듭니다.

### Add UI Component with Storybook
- feature 모듈 및 common, shared 모듈 내 components 폴더에 포함되는 하위 폴더에 우클릭하면 보여집니다.
- React Presentational Component 와 Storybook 파일 2가지를 자동으로 만듭니다.

### Add Storybook for This Component
- 우클릭된 현재 컴포넌트를 대상으로만 Storybook 테스트 코드를 만듭니다.

## Notes <!-- 리뷰어에게 알려줄 내용이나 PR에 히스토리로 남기고 싶은 내용들 -->

- 아직 초기버전이라 내용이 많이 미숙합니다 🥲 
- 코드도 왠지 갈수록 지저분해 지는데, 이건 추 후에 차차 리팩터링 해 나가겠습니다~ 😭 
- 테스트를 위해 이미 배포된 상태입니다. PR 끝나면 close 예정입니다.

## Captures <!-- 캡쳐된 스크린샷이나 영상들 -->

<img width="441" alt="스크린샷 2022-08-11 오전 9 15 37" src="https://user-images.githubusercontent.com/16861056/184048310-48afc7be-6f73-4ca8-9909-fd0ea1561008.png">

<img width="424" alt="스크린샷 2022-08-11 오전 9 15 23" src="https://user-images.githubusercontent.com/16861056/184048322-3e06319f-b48a-4d95-94b0-0dc665b5d201.png">

https://user-images.githubusercontent.com/16861056/184048662-72ad0a76-982e-499a-a71c-19778c3d30dc.mov

## Refs

- https://github.com/thesoncriel/ts-fe-cli/pull/13