### PR TITLE
Chore: jordy-vsce 로 내부 명칭 일괄 변경

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
-# ts-fe-vscode-extension
+# jordy-vsce
 
-업무용으로 ts-fe-cli 와 함께 사용하기 위한 vscode 확장 프로그램 입니다.
+업무용으로 jordy 및 jordy-cli 와 함께 사용하기 위한 vscode 확장 프로그램 입니다.
 
 현재 개발 중입니다. 😅
 
 ## Pre Dependency
 
-본 확장 프로그램 사용 전, 반드시 아래와 같이 [ts-fe-cli](https://github.com/thesoncriel/ts-fe-cli)를 먼저 설치하시기 바랍니다~ 🙌
+본 확장 프로그램 사용 전, 반드시 아래와 같이 [jordy-cli](https://github.com/thesoncriel/jordy-cli)를 먼저 설치하시기 바랍니다~ 🙌
 
 ```sh
-$ npm i -D ts-fe-cli@latest
+$ npm i -D jordy-cli@latest
 ```
 
 그리고 프로젝트 내 `package.json` 에 아래와 같이 script 를 추가 해주세요~!
 ```json
 {
   "scripts": {
-    "cli": "ts-fe-cli"
+    "cli": "jordy-cli"
   },
 }
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ts-fe-vscode-extension",
-  "version": "0.2.3",
+  "version": "0.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ts-fe-vscode-extension",
-      "version": "0.2.3",
+      "version": "0.3.1",
       "devDependencies": {
         "@types/glob": "^7.2.0",
         "@types/mocha": "^9.1.1",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,13 @@
 {
-  "name": "ts-fe-vscode-extension",
-  "displayName": "ts-fe-vscode-extension",
+  "name": "jordy-vsce",
+  "displayName": "jordy-vsce",
   "description": "vscode extension for ts-fe-cli",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "publisher": "theson",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/thesoncriel/jordy-vsce"
+  },
   "engines": {
     "vscode": "^1.60.x"
   },
@@ -11,10 +15,10 @@
     "Other"
   ],
   "activationEvents": [
-    "onCommand:ts-fe-vscode-extension.feat-add",
-    "onCommand:ts-fe-vscode-extension.sub-add",
-    "onCommand:ts-fe-vscode-extension.ui-add",
-    "onCommand:ts-fe-vscode-extension.sb-add"
+    "onCommand:jordy-vsce.feat-add",
+    "onCommand:jordy-vsce.sub-add",
+    "onCommand:jordy-vsce.ui-add",
+    "onCommand:jordy-vsce.sb-add"
   ],
   "main": "./dist/extension.js",
   "contributes": {
@@ -23,40 +27,40 @@
         {
           "when": "explorerResourceIsFolder && resourcePath =~ /features/",
           "group": "z_commands",
-          "command": "ts-fe-vscode-extension.feat-add"
+          "command": "jordy-vsce.feat-add"
         },
         {
           "when": "explorerResourceIsFolder && resourcePath =~ /features\/\\w+|shared/",
           "group": "z_commands",
-          "command": "ts-fe-vscode-extension.sub-add"
+          "command": "jordy-vsce.sub-add"
         },
         {
           "when": "explorerResourceIsFolder && resourcePath =~ /(features\/\\w+|shared|common)\/components/\\w+/",
           "group": "z_commands",
-          "command": "ts-fe-vscode-extension.ui-add"
+          "command": "jordy-vsce.ui-add"
         },
         {
           "when": "resourceExtname == .tsx && resourcePath =~ /(features\/\\w+|shared|common)\/components/",
           "group": "z_commands",
-          "command": "ts-fe-vscode-extension.sb-add"
+          "command": "jordy-vsce.sb-add"
         }
       ]
     },
     "commands": [
       {
-        "command": "ts-fe-vscode-extension.feat-add",
+        "command": "jordy-vsce.feat-add",
         "title": "Add Feature Module"
       },
       {
-        "command": "ts-fe-vscode-extension.sub-add",
+        "command": "jordy-vsce.sub-add",
         "title": "Add Sub Module"
       },
       {
-        "command": "ts-fe-vscode-extension.ui-add",
+        "command": "jordy-vsce.ui-add",
         "title": "Add UI Component with Storybook"
       },
       {
-        "command": "ts-fe-vscode-extension.sb-add",
+        "command": "jordy-vsce.sb-add",
         "title": "Add Storybook for This Component"
       }
     ]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,7 +11,7 @@ interface VscodeExplorerContextDto {
 }
 
 function executeFeatureModule(feature: string, sub: string) {
-	const terminal = vscode.window.createTerminal(`ts-fe-cli-temp-${Date.now()}`);
+	const terminal = vscode.window.createTerminal(`jordy-cli-temp-${Date.now()}`);
 
 	terminal.sendText(`npm run cli feat ${feature} ${sub}`);
 	terminal.sendText('y');
@@ -22,7 +22,7 @@ function executeFeatureModule(feature: string, sub: string) {
 }
 
 function executeSubModule(path: string, sub: string) {
-	const terminal = vscode.window.createTerminal(`ts-fe-cli-temp-${Date.now()}`);
+	const terminal = vscode.window.createTerminal(`jordy-cli-temp-${Date.now()}`);
 
 	terminal.sendText(`npm run cli sub ${path} ${sub}`);
 	terminal.sendText('y');
@@ -33,7 +33,7 @@ function executeSubModule(path: string, sub: string) {
 }
 
 function executeUiComponent(path: string, componentName: string, type: string) {
-	const terminal = vscode.window.createTerminal(`ts-fe-cli-temp-${Date.now()}`);
+	const terminal = vscode.window.createTerminal(`jordy-cli-temp-${Date.now()}`);
 
 	terminal.sendText(`npm run cli ui ${path} ${componentName} ${type}`);
 	terminal.sendText('y');
@@ -44,7 +44,7 @@ function executeUiComponent(path: string, componentName: string, type: string) {
 }
 
 function executeStorybook(path: string, type: string) {
-	const terminal = vscode.window.createTerminal(`ts-fe-cli-temp-${Date.now()}`);
+	const terminal = vscode.window.createTerminal(`jordy-cli-temp-${Date.now()}`);
 
 	terminal.sendText(`npm run cli sb ${path} ${type}`);
 	terminal.sendText('y');
@@ -60,12 +60,12 @@ export function activate(context: vscode.ExtensionContext) {
 	
 	// Use the console to output diagnostic information (console.log) and errors (console.error)
 	// This line of code will only be executed once when your extension is activated
-	console.log('Congratulations, your extension "ts-fe-vscode-extension" is now active!');
+	console.log('Congratulations, your extension "jordy-vsce" is now active!');
 
 	// The command has been defined in the package.json file
 	// Now provide the implementation of the command with registerCommand
 	// The commandId parameter must match the command field in package.json
-	let disposableFeatAdd = vscode.commands.registerCommand('ts-fe-vscode-extension.feat-add', (arg0: VscodeExplorerContextDto, arg1: VscodeExplorerContextDto[]) => {
+	let disposableFeatAdd = vscode.commands.registerCommand('jordy-vsce.feat-add', (arg0: VscodeExplorerContextDto, arg1: VscodeExplorerContextDto[]) => {
 		// The code you place here will be executed every time your command is executed
 		// Display a message box to the user
 		// vscode.window.showInformationMessage(JSON.stringify(arg0) + '\n------\n' + JSON.stringify(arg1));
@@ -102,7 +102,7 @@ export function activate(context: vscode.ExtensionContext) {
 		input1.show();
 	});
 
-	let disposableSubAdd = vscode.commands.registerCommand('ts-fe-vscode-extension.sub-add', (arg0: VscodeExplorerContextDto, arg1: VscodeExplorerContextDto[]) => {
+	let disposableSubAdd = vscode.commands.registerCommand('jordy-vsce.sub-add', (arg0: VscodeExplorerContextDto, arg1: VscodeExplorerContextDto[]) => {
 		const input = vscode.window.createInputBox();
 
 		input.title = 'sub name ?';
@@ -121,7 +121,7 @@ export function activate(context: vscode.ExtensionContext) {
 		input.show();
 	});
 
-	let disposableUiAdd = vscode.commands.registerCommand('ts-fe-vscode-extension.ui-add', (arg0: VscodeExplorerContextDto, arg1: VscodeExplorerContextDto[]) => {
+	let disposableUiAdd = vscode.commands.registerCommand('jordy-vsce.ui-add', (arg0: VscodeExplorerContextDto, arg1: VscodeExplorerContextDto[]) => {
 
 		const input = vscode.window.createInputBox();
 
@@ -153,7 +153,7 @@ export function activate(context: vscode.ExtensionContext) {
 		input.show();
 	});
 
-	let disposableStorybookAdd = vscode.commands.registerCommand('ts-fe-vscode-extension.sb-add', (arg0: VscodeExplorerContextDto, arg1: VscodeExplorerContextDto[]) => {
+	let disposableStorybookAdd = vscode.commands.registerCommand('jordy-vsce.sb-add', (arg0: VscodeExplorerContextDto, arg1: VscodeExplorerContextDto[]) => {
 		const pick = vscode.window.createQuickPick();
 
 		pick.title = 'component type ?';


### PR DESCRIPTION
## Others <!-- 기타 변경점들 (기능에 직접적인 연관이 없는 chore, style 등) -->

사내 라이브러리 명칭이 `jordy` 로 변경됨에 따라 이를 응용하는 vscode 확장 프로그램 명칭도 `jordy-vsce` 로 일괄 변경합니다.

## Notes

해당 변경 사항은 이미 MS Marketplace 에 업데이트 된 상태이므로 리뷰가 끝나면 본 PR을 닫을 예정입니다.